### PR TITLE
pki.h: fix macros for macOS

### DIFF
--- a/src/pki.h
+++ b/src/pki.h
@@ -33,7 +33,7 @@ extern OSSL_LIB_CTX *PKI_ossl_ctx;
 #endif
 
 #if __APPLE__
-#if defined MAC_OS_X_VERSION_10_7 && MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
 /* use accelerated crypto on OS X instead of OpenSSL crypto */
 /* We only use the one-shot functions normally declared in CommonCrypto/CommonDigest.h
    to avoid nonsensical warnings */

--- a/src/pki.h
+++ b/src/pki.h
@@ -49,7 +49,6 @@ extern unsigned char *CC_SHA256(const void *data, uint32_t len, unsigned char *m
 #define SHA256(D,L,H) CC_SHA256(D, (uint32_t)(L), H)
 #undef MD5
 #define MD5(D,L,H) CC_MD5(D, (uint32_t)(L), H)
-#endif
 #else /* !LP64 */
 #undef SHA1
 #define SHA1(D,L,H) do (1) { if ((L) >= 4294967296L) SHA1(D,L,H) else CC_SHA1(D, (uint32_t)(L), H); break }
@@ -58,4 +57,5 @@ extern unsigned char *CC_SHA256(const void *data, uint32_t len, unsigned char *m
 #undef MD5
 #define MD5 do (1) { if ((L) >= 4294967296L) MD5(D,L,H) else CC_MD5(D, (uint32_t)(L), H); break }
 #endif /* LP64 */
+#endif
 #endif


### PR DESCRIPTION
1. Apparently `endif` is in the wrong place now, as follows both from comment to the existing code and a fact that it fails to compile on 10.6. Fix that, so that the package can actually build. (I wonder how no one noticed this so far.)

2. Simplify the macro for macOS version: there is no need to check if `MAC_OS_X_VERSION_10_7` is defined, `MAC_OS_X_VERSION_MIN_REQUIRED` on its own works.